### PR TITLE
ci: reinstate a basic Test workflow to fix test badges

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+on: [push]
+name: Test
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - run: echo Hello, world!


### PR DESCRIPTION
Existing versions of CUE that render on sites like pkg.go.dev have a
link to the following test badge:

    https://github.com/cuelang/cue/workflows/Test/badge.svg

If we don't have a Test workflow, this shows as red. Which is a bad
signal for all existing versions of CUE that people might view on
pkg.go.dev.

Fix that by re-instating a dummy Test workflow that will always succeed.

Incidentally, this might be a reason _against_ archiving this
repository.

Change-Id: Ifb7fed4fe5bd35f9f416095e650ae79e87396517
Reviewed-on: https://cue-review.googlesource.com/c/cue/+/10061
Reviewed-by: Paul Jolly <paul@myitcv.org.uk>